### PR TITLE
Fix error with scriptParameters variable

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -50,7 +50,7 @@
       "scriptLocation": "AddDatabaseToSqlServer.ps1",
       "scripturi": "https://raw.githubusercontent.com/MicrosoftDocs/mslearn-migrate-sql-server-relational-data/master/AddDatabaseToSqlServer.ps1",
       "scriptFiles": "[createarray(variables('scripturi'))]",
-      "scriptParameters": "[concat('-userName ', parameters('sourceSqlAdminUserName'), ' -password \"', parameters('sourceSqlAdminPassword'))]",
+      "scriptParameters": "[concat('-userName ', parameters('sourceSqlAdminUserName'), ' -password \"', parameters('sourceSqlAdminPassword'), '\"')]",
       "storageAccountNamePrefix": "admsdemost",
       "storageAccountName": "[toLower(concat(variables('storageAccountNamePrefix'), uniqueString(resourceGroup().id)))]",
       "sourceNicName": "admsdemo-nic",


### PR DESCRIPTION
When this deployment runs the custom script extension currently fails to execute because the parameters passed to the script are missing a closing speech mark at the end of the sql password. Updated variable to fix this issue