### PR TITLE
Enabled tls1.2 communication with package repository

### DIFF
--- a/AddDatabaseToSqlServer.ps1
+++ b/AddDatabaseToSqlServer.ps1
@@ -15,6 +15,9 @@ if ((Get-Command Install-PackageProvider -ErrorAction Ignore) -eq $null)
 }
 else
 {
+        # Ensure server can communicate with repository
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 	# Conflicts with SqlServer module
 	Remove-Module -Name SQLPS -ErrorAction Ignore;
 


### PR DESCRIPTION
The script currently fails on a newly built Windows server because tls1.2 communication is not enabled by default. This fixes the issue by enabling it before any calls to the repository are made